### PR TITLE
App crash when importing module

### DIFF
--- a/example/index.android.js
+++ b/example/index.android.js
@@ -34,7 +34,7 @@ const translations = {
     welcome: 'This text depends on the selected culture'
   },
   es: {
-    welcome. 'Este texto depende de la cultura seleccionada'
+    welcome: 'Este texto depende de la cultura seleccionada'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "url": "https://github.com/line64/react-native-culture-text/issues"
   },
   "homepage": "https://github.com/line64/react-native-culture-text#readme",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "devDependencies": {
     "react": "15.4.0-rc.4",
     "react-native": "0.40"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/line64/react-native-culture-text/issues"
   },
   "homepage": "https://github.com/line64/react-native-culture-text#readme",
-  "dependencies": {
+  "devDependencies": {
     "react": "15.4.0-rc.4",
     "react-native": "0.40"
   }


### PR DESCRIPTION
After installing module, and restarting react-native's packager, app crashed with the following error:

**This error is caused by a @providesModule declaration with the same name across two different files.
Error: @providesModule naming collision:
  Duplicate module name: react-native**

Solution: react & react-native must be moved from module's _dependencies_, to _devDependencies_