### PR TITLE
Locale fallback implementation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ export function getBestMessageTranslation(translations, culture, messageKey) {
 
   if (!messageKey || !culture || !translations) return null;
 
-  let lang = translations[_localeFallback(culture)];
+  let lang = translations[getLangFromLocale(culture)];
 
   if (!lang) return null;
 
@@ -20,14 +20,12 @@ export function mergeTranslations(baseTranslations, overrideTranslations) {
 
 }
 
-function _localeFallback(locale) {
+function getLangFromLocale(locale) {
 
-  if (locale.indexOf('-') !== -1)
-      locale = locale.split('-')[0];
-
-  if (locale.indexOf('_') !== -1)
-      locale = locale.split('_')[0];
+  if(/^(?:[a-z]{2})(?:(_|-)[A-Z]{2})?$/.test(locale)) {
+    return locale.substring(0,2);
+  };
+  return null;
   
-  return locale;
-
 };
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,12 +3,16 @@ export function getBestMessageTranslation(translations, culture, messageKey) {
 
   if (!messageKey || !culture || !translations) return null;
 
-  let lang = translations[getLangFromLocale(culture)];
+  let lang;
 
-  if (!lang) return null;
+  if (translations[culture])
+    lang = translations[culture];
+  else if (translations[getLangFromLocale(culture)])
+    lang = translations[getLangFromLocale(culture)];
+  else 
+    return null;
 
   return lang[messageKey];
-
 }
 
 export function mergeTranslations(baseTranslations, overrideTranslations) {
@@ -21,11 +25,8 @@ export function mergeTranslations(baseTranslations, overrideTranslations) {
 }
 
 function getLangFromLocale(locale) {
-
-  if(/^(?:[a-z]{2})(?:(_|-)[A-Z]{2})?$/.test(locale)) {
-    return locale.substring(0,2);
-  };
-  return null;
-  
+  let re = /^[A-Za-z]{2}/,
+  result = re.exec(locale);
+  return result[0];  
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,7 @@ export function getBestMessageTranslation(translations, culture, messageKey) {
 
   if (!messageKey || !culture || !translations) return null;
 
-  //TODO: this is a quick draft, should improve fallback procedure
-  let lang = translations[culture];
+  let lang = translations[_localeFallback(culture)];
 
   if (!lang) return null;
 
@@ -20,3 +19,15 @@ export function mergeTranslations(baseTranslations, overrideTranslations) {
   };
 
 }
+
+function _localeFallback(locale) {
+
+  if (locale.indexOf('-') !== -1)
+      locale = locale.split('-')[0];
+
+  if (locale.indexOf('_') !== -1)
+      locale = locale.split('_')[0];
+  
+  return locale;
+
+};


### PR DESCRIPTION
For example, `en-US`, `en-GB` and `en` will fallback to `en`
